### PR TITLE
Add '/sap/opu/odata4/**' to pathFilter in Gateway.ts

### DIFF
--- a/src/Server/Proxy/Odata/Gateway.ts
+++ b/src/Server/Proxy/Odata/Gateway.ts
@@ -22,7 +22,7 @@ const Gateway = {
         xfwd: true,
         logger: Log.newLogProviderProxy(),
         auth: getODATAAuth() ?? undefined,
-        pathFilter: ['/sap/opu/odata/**', '/sap/public/bc/themes/**', '/sap/bc/**'],
+        pathFilter: ['/sap/opu/odata/**', '/sap/opu/odata4/**', '/sap/public/bc/themes/**', '/sap/bc/**'],
       });
       serverApp.use(proxy);
     }


### PR DESCRIPTION
## Description of the Change
I have updated the proxy configuration to include support for OData v4 paths. The pathFilter of the proxy now includes the route /sap/opu/odata4/**, allowing access to OData v4 services through the proxy.

## Changes Made
Added /sap/opu/odata4/** to the pathFilter in the createProxyMiddleware configuration.

## Reason for the Change
This change is necessary to support communication with OData v4 services in the project and to ensure that routes for the new version of OData are properly handled by the proxy.

## Expected Impact
With this change, OData v4 services can be accessed without requiring additional configurations in the proxy.